### PR TITLE
Fix `Failed to activate the atom-ctags package`

### DIFF
--- a/src/ctags.coffee
+++ b/src/ctags.coffee
@@ -1,4 +1,4 @@
-{Tags} = require('../build/Release/ctags.node')
+{Tags} = require(process.resourcesPath + '/app.asar.unpacked/node_modules/ctags/build/Release/ctags.node')
 es = require 'event-stream'
 
 exports.findTags = (tagsFilePath, tag, options, callback) ->


### PR DESCRIPTION
Fixes [this](https://github.com/yongkangchen/atom-ctags/issues/145)
